### PR TITLE
Fix quality-kit/230707_QUALITY_FLEET_VEHICLES_v1.0.0.zip Issue #11

### DIFF
--- a/quality-kit/230707_QUALITY_FLEET_VEHICLES_v1.0.0.zip
+++ b/quality-kit/230707_QUALITY_FLEET_VEHICLES_v1.0.0.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:77f40b73d6c0449d95ec5474d17e89e71c1e73ab56b95dd21b614a71b376044b
-size 63034562


### PR DESCRIPTION
Delete corrupt file --> replace with new working file



## Description

Fix Issue '11 - Corrupt archive 20230707-io.catenax.fleet.vehicles.zip
--> Deleted corrupt zip-file and replace by new working one


## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
