### PR TITLE
fix broken quality-kit file vehicles

### DIFF
--- a/quality-kit/20230707-io.catenax.fleet.vehicles.zip
+++ b/quality-kit/20230707-io.catenax.fleet.vehicles.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:018c1ee7f6bec20a50cc790149d8f512919decefdbaba9bfc60700dddadc1cb8
-size 5521945
+oid sha256:77f40b73d6c0449d95ec5474d17e89e71c1e73ab56b95dd21b614a71b376044b
+size 63034562

--- a/quality-kit/230707_QUALITY_FLEET_VEHICLES_v1.0.0.zip
+++ b/quality-kit/230707_QUALITY_FLEET_VEHICLES_v1.0.0.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:77f40b73d6c0449d95ec5474d17e89e71c1e73ab56b95dd21b614a71b376044b
-size 63034562


### PR DESCRIPTION
File was uploaded with crc issues. This commit replaces it with the correct one.

<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
