### PR TITLE
docs(open planning): add planning slides R25.03

### DIFF
--- a/presentations/R25.03_SLIDES_REFINEMENTDAY_TWO.pdf
+++ b/presentations/R25.03_SLIDES_REFINEMENTDAY_TWO.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:613766aa1365a855c853bdd73869e57000aa0758107cb1abf95d61a7c7e9ab92
+size 2018394

--- a/presentations/R25.03_SLIDES_REFINEMENTDAY_TWO.pdf.license
+++ b/presentations/R25.03_SLIDES_REFINEMENTDAY_TWO.pdf.license
@@ -1,0 +1,6 @@
+## Notice
+
+This work is licensed under the [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode)
+
+- SPDX-License-Identifier: CC-BY-4.0
+- SPDX-FileCopyrightText: 2024 Contributors to the Eclipse Foundation

--- a/presentations/R25.03_SLIDES_RELEASE_PLANNING.pdf
+++ b/presentations/R25.03_SLIDES_RELEASE_PLANNING.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d20564e877ed11e23499c6beef38114f8b0d577200a27e7a3fad883cc17d7fde
+size 2313065

--- a/presentations/R25.03_SLIDES_RELEASE_PLANNING.pdf.license
+++ b/presentations/R25.03_SLIDES_RELEASE_PLANNING.pdf.license
@@ -1,0 +1,6 @@
+## Notice
+
+This work is licensed under the [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode)
+
+- SPDX-License-Identifier: CC-BY-4.0
+- SPDX-FileCopyrightText: 2024 Contributors to the Eclipse Foundation


### PR DESCRIPTION
## Description

This PR adds the slides for our open planning R25.03

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
