### PR TITLE
docs(open planning): add slides for release planning 25.09

### DIFF
--- a/presentations/R25.09_SLIDES_RELEASE_PLANNING.pdf
+++ b/presentations/R25.09_SLIDES_RELEASE_PLANNING.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:004fb35706ec2fa829196cd135421af060346d7c49369a82d467210e8dcdcd41
+size 2596381

--- a/presentations/R25.09_SLIDES_RELEASE_PLANNING.pdf.license
+++ b/presentations/R25.09_SLIDES_RELEASE_PLANNING.pdf.license
@@ -1,0 +1,6 @@
+## Notice
+
+This work is licensed under the [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode)
+
+- SPDX-License-Identifier: CC-BY-4.0
+- SPDX-FileCopyrightText: 2024 Contributors to the Eclipse Foundation

--- a/presentations/R25.09_SLIDES_RELEASE_PLANNING.pdf.license
+++ b/presentations/R25.09_SLIDES_RELEASE_PLANNING.pdf.license
@@ -3,4 +3,4 @@
 This work is licensed under the [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode)
 
 - SPDX-License-Identifier: CC-BY-4.0
-- SPDX-FileCopyrightText: 2024 Contributors to the Eclipse Foundation
+- SPDX-FileCopyrightText: 2025 Contributors to the Eclipse Foundation


### PR DESCRIPTION
## Description

This PR adds the slides for the open planning R25.09

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
